### PR TITLE
ci(release-schedule): disable cron

### DIFF
--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -1,8 +1,8 @@
 name: "Release: Scheduled"
 
 on:
-  schedule:
-    - cron: "0 0 * * 5" # Every Friday at 00:00 AM UTC on the default branch
+#   schedule:
+#     - cron: "0 0 * * 5" # Every Friday at 00:00 AM UTC on the default branch
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
There are currently no automated updates to project dependencies, so a cron release schedule can be disabled.