### PR TITLE
chore(docker): correct pnpm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #############
 # Create base image.
 
-FROM node:22.11.0-alpine AS base-image
+FROM node:22.14.0-alpine AS base-image
 
 # The `CI` environment variable must be set for pnpm to run in headless mode
 ENV CI=true
@@ -71,7 +71,7 @@ EXPOSE 80
 # #######################
 # # Serve node for production.
 
-# FROM node:22.11.0-alpine AS production
+# FROM node:22.14.0-alpine AS production
 
 # # The `CI` environment variable must be set for pnpm to run in headless mode
 # ENV CI=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN corepack enable
 
 FROM base-image AS prepare
 
-COPY ./pnpm-lock.yaml ./
+COPY ./pnpm-lock.yaml package.json ./
 
 RUN pnpm fetch
 


### PR DESCRIPTION
Without the `package.json` being available at installation, another pnpm version may be used.